### PR TITLE
using aws-sdk v3 instead of v2.

### DIFF
--- a/cloudwatchlogger.gemspec
+++ b/cloudwatchlogger.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'uuid', '~> 2'
   s.add_runtime_dependency 'multi_json', '~> 1'
-  s.add_runtime_dependency 'aws-sdk', '~> 2'
+  s.add_runtime_dependency 'aws-sdk-cloudwatchlogs', '~> 1'
 end

--- a/lib/cloudwatchlogger/client/aws_sdk/threaded.rb
+++ b/lib/cloudwatchlogger/client/aws_sdk/threaded.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-cloudwatchlogs'
 require 'thread'
 
 module CloudWatchLogger
@@ -44,14 +44,14 @@ module CloudWatchLogger
 
           super do
             loop do
-              
+
               if @client.nil?
                 connect! opts
               end
-              
+
               msg = @queue.pop
               break if msg == :__delivery_thread_exit_signal__
-              
+
               begin
                 event = {
                   log_group_name: @log_group_name,
@@ -61,7 +61,7 @@ module CloudWatchLogger
                     message: msg
                   }]
                 }
-                
+
                 if token = @sequence_token
                   event[:sequence_token] = token
                 end
@@ -93,7 +93,7 @@ module CloudWatchLogger
         def deliver(message)
           @queue.push(message)
         end
-        
+
         def connect!(opts={})
           @client = Aws::CloudWatchLogs::Client.new(
             region: @opts[:region] || 'us-east-1',

--- a/lib/cloudwatchlogger/version.rb
+++ b/lib/cloudwatchlogger/version.rb
@@ -1,5 +1,5 @@
 module CloudWatchLogger
 
-  VERSION = '0.1.1'
+  VERSION = '0.2.0'
 
 end


### PR DESCRIPTION
This let's the gem just include the cloudwatchlogs part of the sdk instead of the entire aws-sdk stack.