### PR TITLE
Added rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,14 @@
+Style/Documentation:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Gemspec/OrderedDependencies:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ Will produce the following log message in CloudWatch Logs:
 "<Date> severity=WARN, boom=box, bar=soap"
 ```
 
+## Rubocop
+
+To run Rubocop and check for code smells, issue this command
+
+```
+rubocop -D
+```
+
 Releasing
 -----
 

--- a/cloudwatchlogger.gemspec
+++ b/cloudwatchlogger.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'uuid', '~> 2'
   s.add_runtime_dependency 'multi_json', '~> 1'
   s.add_runtime_dependency 'aws-sdk-cloudwatchlogs', '~> 1'
+
+  s.add_development_dependency 'rubocop', '0.58.1'
 end


### PR DESCRIPTION
This is the output of the first run

```shell
Inspecting 8 files
CCCW.WC.

Offenses:

cloudwatchlogger.gemspec:11:25: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  s.license           = "http://opensource.org/licenses/MIT"
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cloudwatchlogger.gemspec:13:26: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  s.authors           = ["Zane Shannon"]
                         ^^^^^^^^^^^^^^
cloudwatchlogger.gemspec:17:25: C: Style/PercentLiteralDelimiters: %w-literals should be delimited by [ and ].
  s.files             = %w{ README.md Gemfile LICENSE cloudwatchlogger.gemspec } + Dir["lib/**/*.rb"]
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cloudwatchlogger.gemspec:17:28: C: Layout/SpaceInsidePercentLiteralDelimiters: Do not use spaces inside percent literal delimiters.
  s.files             = %w{ README.md Gemfile LICENSE cloudwatchlogger.gemspec } + Dir["lib/**/*.rb"]
                           ^
cloudwatchlogger.gemspec:17:79: C: Layout/SpaceInsidePercentLiteralDelimiters: Do not use spaces inside percent literal delimiters.
  s.files             = %w{ README.md Gemfile LICENSE cloudwatchlogger.gemspec } + Dir["lib/**/*.rb"]
                                                                              ^
cloudwatchlogger.gemspec:17:88: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  s.files             = %w{ README.md Gemfile LICENSE cloudwatchlogger.gemspec } + Dir["lib/**/*.rb"]
                                                                                       ^^^^^^^^^^^^^
cloudwatchlogger.gemspec:19:29: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  s.test_files        = Dir["spec/**/*.rb"]
                            ^^^^^^^^^^^^^^
cloudwatchlogger.gemspec:21:33: C: Gemspec/RequiredRubyVersion: required_ruby_version (1.8, declared in cloudwatchlogger.gemspec) and TargetRubyVersion (2.2, which may be specified in .rubocop.yml) should be equal.
  s.required_ruby_version     = '>= 1.8.6'
                                ^^^^^^^^^^
Rakefile:4:14: C: Style/ExpandPathArguments: Use expand_path('lib/cloudwatchlogger/version', __dir__) instead of expand_path('../lib/cloudwatchlogger/version', __FILE__).
require File.expand_path('../lib/cloudwatchlogger/version', __FILE__)
             ^^^^^^^^^^^
Rakefile:8:6: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  sh "gem build cloudwatchlogger.gemspec"
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Rakefile:12:6: C: Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
task :install => :build do
     ^^^^^^^^^^^
Rakefile:17:6: C: Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
task :release => :build do
     ^^^^^^^^^^^
Rakefile:19:6: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  sh "git push origin master"
     ^^^^^^^^^^^^^^^^^^^^^^^^
Gemfile:1:8: C: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
source "https://rubygems.org"
       ^^^^^^^^^^^^^^^^^^^^^^
Gemfile:8:4: C: Layout/TrailingBlankLines: Final newline missing.
end

lib/cloudwatchlogger/client.rb:3:1: W: Lint/UnneededRequireStatement: Remove unnecessary require statement.
require 'thread'
^^^^^^^^^^^^^^^^
lib/cloudwatchlogger/client.rb:21:7: C: Metrics/AbcSize: Assignment Branch Condition size for masher is too high. [16.12/15]
      def masher(hash, prefix = nil) ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/cloudwatchlogger/client.rb:81:9: C: Naming/MemoizedInstanceVariableName: Memoized variable @log_stream_name does not match method name default_log_stream_name. Use @default_log_stream_name instead.
        @log_stream_name ||= "#{Socket.gethostname}-#{uuid.generate}"
        ^^^^^^^^^^^^^^^^
lib/cloudwatchlogger/client/aws_sdk/threaded.rb:2:1: W: Lint/UnneededRequireStatement: Remove unnecessary require statement.
require 'thread'
^^^^^^^^^^^^^^^^
lib/cloudwatchlogger/client/aws_sdk/threaded.rb:6:11: C: Naming/ClassAndModuleCamelCase: Use CamelCase for classes and modules.
    class AWS_SDK
          ^^^^^^^
lib/cloudwatchlogger/client/aws_sdk/threaded.rb:38:9: C: Metrics/AbcSize: Assignment Branch Condition size for initialize is too high. [29.98/15]
        def initialize(credentials, log_group_name, log_stream_name, opts = {}) ...
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/cloudwatchlogger/client/aws_sdk/threaded.rb:38:9: C: Metrics/CyclomaticComplexity: Cyclomatic complexity for initialize is too high. [8/6]
        def initialize(credentials, log_group_name, log_stream_name, opts = {}) ...
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/cloudwatchlogger/client/aws_sdk/threaded.rb:38:9: C: Metrics/PerceivedComplexity: Perceived complexity for initialize is too high. [8/7]
        def initialize(credentials, log_group_name, log_stream_name, opts = {}) ...
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/cloudwatchlogger/client/aws_sdk/threaded.rb:113:11: W: Lint/HandleExceptions: Do not suppress exceptions.
          rescue Aws::CloudWatchLogs::Errors::ResourceAlreadyExistsException
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/cloudwatchlogger/client/aws_sdk.rb:5:11: C: Naming/ClassAndModuleCamelCase: Use CamelCase for classes and modules.
    class AWS_SDK
          ^^^^^^^

8 files inspected, 25 offenses detected
```