### PR TITLE
Gemspec fixes

### DIFF
--- a/cloudwatchlogger.gemspec
+++ b/cloudwatchlogger.gemspec
@@ -5,10 +5,10 @@ Gem::Specification.new do |s|
   s.name              = 'cloudwatchlogger'
   s.version           = CloudWatchLogger::VERSION
   s.date              = Time.now
-  s.summary           = 'AWS CloudWatchLogs compatiable logger for ruby.'
+  s.summary           = 'Amazon CloudWatch Logs compatiable logger for ruby.'
   s.description       = 'Logger => CloudWatchLogs'
 
-  s.license           = "http://opensource.org/licenses/MIT"
+  s.license           = "MIT"
 
   s.authors           = ["Zane Shannon"]
   s.email             = 'z@zcs.me'


### PR DESCRIPTION
Updates the license code to one that `gem build` recognises, and provides the correct product name for CloudWatch logs.