### PR TITLE
Allow credentials to be loaded from default provider chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ log = CloudWatchLogger.new({access_key_id: 'YOUR_ACCESS_KEY_ID', secret_access_k
 log.info("Hello World from Ruby")
 ```
 
-In case you need to pass different region or group's different Log Stream name:
+The region will default to the value of the environment variable `AWS_REGION`. In case you need to pass different region or group's different Log Stream name:
 
 ```ruby
 log = CloudWatchLogger.new({
@@ -28,6 +28,12 @@ log = CloudWatchLogger.new({
   secret_access_key: 'YOUR_SECRET_ACCESS_KEY'
 }, 'YOUR_CLOUDWATCH_LOG_GROUP', 'YOUR_CLOUDWATCH_LOG_STREAM', region: 'YOUR_CLOUDWATCH_REGION' )
 ```
+
+Provding an empty hash instead of credentials will cause the AWS SDK to search the default credential provider chain for credentials, namely:
+
+1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+1. Amazon ECS container credentials (task role)
+1. Instance profile credentials (IAM role)
 
 ### With Rails
 

--- a/lib/cloudwatchlogger/client/aws_sdk/threaded.rb
+++ b/lib/cloudwatchlogger/client/aws_sdk/threaded.rb
@@ -93,13 +93,11 @@ module CloudWatchLogger
         end
 
         def connect!(opts = {})
-          @client = Aws::CloudWatchLogs::Client.new(
-            region: @opts[:region] || 'us-east-1',
-            access_key_id: @credentials[:access_key_id],
-            secret_access_key: @credentials[:secret_access_key],
-            http_open_timeout: opts[:open_timeout],
-            http_read_timeout: opts[:read_timeout]
-          )
+          args = { http_open_timeout: opts[:open_timeout], http_read_timeout: opts[:read_timeout] }
+          args[:region] = @opts[:region] if @opts[:region]
+          args.merge( @credentials.key?(:access_key_id) ? { access_key_id: @credentials[:access_key_id], secret_access_key: @credentials[:secret_access_key] } : {} )
+
+          @client = Aws::CloudWatchLogs::Client.new(args)
           begin
             @client.create_log_stream(
               log_group_name: @log_group_name,


### PR DESCRIPTION
The goal of this PR is to eliminate the requirement to provision a fixed key and secret. This allows the AWS SDK to search the default provider chain for credentials, and allows the use of [IAM Rolles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) and [ECS task roles](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html).

Roles are preferred over static credentials as they will automatically provide rolling, time-limited credentials managed by the underlying SDK.

This PR also  removes the hardcoded `us-east-1` region. If the region is not specified, the default behaviour of the AWS SDK is to look for an environment variable called `AWS_REGION`.

I know that passing an empty hash is not the most elegant approach, but handling it the way the AWS SDK itself does requires named parameters, which would be a breaking change for current users of cloudwatchlogger.