### PR TITLE
Ensure timestamp for CloudWatch is the time of the log entry

### DIFF
--- a/lib/cloudwatchlogger/client.rb
+++ b/lib/cloudwatchlogger/client.rb
@@ -37,7 +37,7 @@ module CloudWatchLogger
         proc do |severity, datetime, progname, msg|
           processid = Process.pid
           if @format == :json && msg.is_a?(Hash)
-            MultiJson.dump(msg.merge(severity: severity,
+            message = MultiJson.dump(msg.merge(severity: severity,
                                      datetime: datetime,
                                      progname: progname,
                                      pid: processid))
@@ -45,6 +45,11 @@ module CloudWatchLogger
             message = "#{datetime} "
             message << massage_message(msg, severity, processid)
           end
+
+          {
+            message:    message,
+            epoch_time: epoch_from(datetime)
+          }
         end
       end
 
@@ -79,6 +84,10 @@ module CloudWatchLogger
       def default_log_stream_name
         uuid = UUID.new
         @log_stream_name ||= "#{Socket.gethostname}-#{uuid.generate}"
+      end
+
+      def epoch_from(datetime)
+        (datetime.utc.to_f.round(3) * 1000).to_i
       end
     end
   end

--- a/lib/cloudwatchlogger/client/aws_sdk/threaded.rb
+++ b/lib/cloudwatchlogger/client/aws_sdk/threaded.rb
@@ -50,16 +50,16 @@ module CloudWatchLogger
             loop do
               connect!(opts) if @client.nil?
 
-              msg = @queue.pop
-              break if msg == :__delivery_thread_exit_signal__
+              message_object = @queue.pop
+              break if message_object == :__delivery_thread_exit_signal__
 
               begin
                 event = {
                   log_group_name: @log_group_name,
                   log_stream_name: @log_stream_name,
                   log_events: [{
-                    timestamp: (Time.now.utc.to_f.round(3) * 1000).to_i,
-                    message: msg
+                    timestamp: message_object[:epoch_time],
+                    message:   message_object[:message]
                   }]
                 }
                 event[:sequence_token] = @sequence_token if @sequence_token


### PR DESCRIPTION
Currently, the `timestamp` value that's used on the `log_events` objects is the
time at which the event object is created and sent to CloudWatch.

This does not always accurately reflect the `datetime` value of the entry
actually being logged in the logger. In the case of latency between a message
being pushed onto the queue (possibly a large queue), and it being popped off,
the times will be different.

The times in the actual log message will be accurate (see below), as they are
derived from `datetime`, but the epoch time sent to CloudWatch will differ.

Ensuring the time used for the `timestamp` value sent to CloudWatch is the time
when the entry was logged, will also help if in the future, batch posting
multiple entries is supported.

Below is an example illustrating how there can be a disparity between times
currently, and how this PR helps to resolve that:

**Before:**
```
# app log
[24/Jun/2019:14:28:59 -0400] "POST /log HTTP/1.1" 202 21 0.0044

# generated log object (note the same time as the app logs)
2019-06-24 14:28:59 -0400 pid=1, thread=1, severity=INFO, {}

###
20 SECOND SLEEP
###

# epoch time sent to CloudWatch (and conversion)
# note this time is different, post-delay
1561400960123 (2019-06-24 14:29:20.123)
```

**After:**
```
# app log
[24/Jun/2019:14:22:30 -0400] "POST /log HTTP/1.1" 202 21 0.0032

# generated log object (note the same time as the app logs)
2019-06-24 14:22:30 -0400 pid=2, thread=2, severity=INFO, {}

###
20 SECOND SLEEP
###

# epoch time sent to CloudWatch (and conversion)
# note this time is the same, post-delay
1561400550831 (2019-06-24 14:22:30.831)
```

- determine epoch time from `datetime`
- during formatting, normalize an object that we can store this more accurate timestamp on
- reference the new `message_object[:epoch_time]` to set the `timestamp` on the CloudWatch entries
- reference the new `message_object[:message]` to pass through the message, unchanged