### PR TITLE
Rescue for AccessDeniedException to CreateLogStream

### DIFF
--- a/lib/cloudwatchlogger/client/aws_sdk/threaded.rb
+++ b/lib/cloudwatchlogger/client/aws_sdk/threaded.rb
@@ -110,7 +110,8 @@ module CloudWatchLogger
               log_group_name: @log_group_name
             )
             retry
-          rescue Aws::CloudWatchLogs::Errors::ResourceAlreadyExistsException
+          rescue Aws::CloudWatchLogs::Errors::ResourceAlreadyExistsException, 
+            Aws::CloudWatchLogs::Errors::AccessDeniedException
           end
         end
       end


### PR DESCRIPTION
This allows limited accounts who can only `put_log_events` to use this library. 
Otherwise there is an error thrown as Rails is initialized when there is an uncaught exception Aws::CloudWatchLogs::Errors::AccessDeniedException