### PR TITLE
allow format to be passed as an option

### DIFF
--- a/lib/cloudwatchlogger.rb
+++ b/lib/cloudwatchlogger.rb
@@ -11,7 +11,7 @@ module CloudWatchLogger
     logger = Logger.new(client)
 
     if client.respond_to?(:formatter)
-      logger.formatter = client.formatter
+      logger.formatter = client.formatter(opts[:format])
     elsif client.respond_to?(:datetime_format)
       logger.datetime_format = client.datetime_format
     end

--- a/lib/cloudwatchlogger/client.rb
+++ b/lib/cloudwatchlogger/client.rb
@@ -33,10 +33,10 @@ module CloudWatchLogger
         end.join(', ')
       end
 
-      def formatter
+      def formatter(format=nil)
         proc do |severity, datetime, progname, msg|
           processid = Process.pid
-          if @format == :json && msg.is_a?(Hash)
+          if format == :json && msg.is_a?(Hash)
             message = MultiJson.dump(msg.merge(severity: severity,
                                      datetime: datetime,
                                      progname: progname,


### PR DESCRIPTION
this lets us pass format: :json so the log is a valid json object. This
way, we can make use of CloudWatch "Discovered Fields" for much easier
filtering.

fixes #14 