### PR TITLE
Ensure backwards compatibility when default log formatter is not used

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ Will produce the following log message in CloudWatch Logs:
 "<Date> severity=WARN, boom=box, bar=soap"
 ```
 
+### Custom Log Formatters
+The default formatter in this gem ensures that the timestamp sent to cloudwatch will reflect the time the message was pushed onto the queue. If you want to use a custom log formatter, in order for you to not have a disparity between your actual log time and the time reflected in CloudWatch, you will need to ensure your formatter is a `Hash` with a key for `message` which will contain your log message, and `epoch_time` which should be an epoch time formatted timestamp for your log entry, like so:
+
+```ruby
+logger.formatter = proc do |severity, datetime, progname, msg|
+  {
+    message:    "CUSTOM FORMATTER PREFIX: #{msg}\n",
+    epoch_time: (datetime.utc.to_f.round(3) * 1000).to_i
+  }
+end
+```
+
 Releasing
 -----
 


### PR DESCRIPTION
**Fix for issue: https://github.com/zshannon/cloudwatchlogger/issues/16**

In order for changes in #12 to not cause breakage, it assumes that the default
formatter is used, or that a custom formatter would have `epoch_time` and `message`
available on the `Hash` object.

These changes leave the default formatter changes in place, but ensure that the
`timestamp` and `message` values on the log events revert to the original values
prior to #12 if the message on the queue is not a `Hash` and does not contain
`epoch_time` and `message` values. This will allow backwards compatibility and
also allow for custom formatters to still pass these values in if they wish to
benefit from the timestamp disparity.

**This bug can be exploited with the following:**

```ruby
# gem install cloudwatchlogger -v 0.3.0
# gem list cloudwatchlogger (ensure you only have, or are at least using version 0.3.0)

require 'cloudwatchlogger'
logger = CloudWatchLogger.new({
        :access_key_id     => "<ACCESS_KEY_ID>",
        :secret_access_key => "<SECRET_ACCESS_KEY>"
      },
      "<LOG_GROUP>",
      "<LOG_STREAM>",
      :region => "us-east-1"
    )

# this works with the new default logger changes
logger.info("happy!")

logger.formatter = proc do |severity, datetime, progname, msg|
  "CUSTOM FORMATTER: #{msg}\n"
end

# this breaks, with a custom logger that is just a string
logger.info("sad...")
```

With the changes in this PR, you should now see _both_ of the above examples
succeed, **_as well as the following custom formatter:_**

```ruby
logger.formatter = proc do |severity, datetime, progname, msg|
  {
    message:    "CUSTOM FORMATTER PREFIX: #{msg}\n", 
    epoch_time: (datetime.utc.to_f.round(3) * 1000).to_i
  }

logger.info("This works now, too!")
end
```
