### PR TITLE
If logger is passed as an option, pass it along to the client

### DIFF
--- a/lib/cloudwatchlogger/client/aws_sdk/threaded.rb
+++ b/lib/cloudwatchlogger/client/aws_sdk/threaded.rb
@@ -90,7 +90,8 @@ module CloudWatchLogger
         end
 
         def connect!(opts = {})
-          args = { http_open_timeout: opts[:open_timeout], http_read_timeout: opts[:read_timeout], logger: opts[:logger] }
+          args = { http_open_timeout: opts[:open_timeout], http_read_timeout: opts[:read_timeout] }
+          args[:logger] = @opts[:logger] if @opts[:logger]
           args[:region] = @opts[:region] if @opts[:region]
           args.merge!( @credentials.key?(:access_key_id) ? { access_key_id: @credentials[:access_key_id], secret_access_key: @credentials[:secret_access_key] } : {} )
 

--- a/lib/cloudwatchlogger/client/aws_sdk/threaded.rb
+++ b/lib/cloudwatchlogger/client/aws_sdk/threaded.rb
@@ -90,7 +90,7 @@ module CloudWatchLogger
         end
 
         def connect!(opts = {})
-          args = { http_open_timeout: opts[:open_timeout], http_read_timeout: opts[:read_timeout] }
+          args = { http_open_timeout: opts[:open_timeout], http_read_timeout: opts[:read_timeout], logger: opts[:logger] }
           args[:region] = @opts[:region] if @opts[:region]
           args.merge!( @credentials.key?(:access_key_id) ? { access_key_id: @credentials[:access_key_id], secret_access_key: @credentials[:secret_access_key] } : {} )
 


### PR DESCRIPTION
We had an issue in https://github.com/neinteractiveliterature/intercode in which the logger client itself was logging messages about itself logging to CloudWatch.  This dramatically increased the number of logs we were sending to CloudWatch, to the tune of about $40/month extra.

I wanted to solve this by passing a custom `logger` option along to the AWS SDK client that would only output warnings and errors, and do so to STDERR rather than to CloudWatch, but cloudwatchlogger wasn't passing along the option to the AWS SDK client even if it was passed in `opts`.  This patch extends cloudwatchlogger to do so.

After doing this, this configuration works for our use case:

```ruby
  # Don't log about every log message attempt
  logger_logger = Logger.new($stderr)
  logger_logger.level = Logger::WARN

  cloudwatch_logger =
    CloudWatchLogger.new(
      {},
      ENV["CLOUDWATCH_LOG_GROUP"],
      dyno_type || ENV["CLOUDWATCH_LOG_STREAM_NAME"] || "intercode",
      { format: :json, logger: logger_logger }
    )
```